### PR TITLE
feat(core, resource-readers): split into Packata.Core and Packata.ResourceReaders

### DIFF
--- a/Packata.sln
+++ b/Packata.sln
@@ -36,6 +36,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Edit", "Edit", "{210C887C-6
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Packata.Core.Testing", "src\Packata.Core.Testing\Packata.Core.Testing.csproj", "{6F8E7D81-19C5-49F9-9E6C-117947D755ED}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Packata.ResourceReaders", "src\Packata.ResourceReaders\Packata.ResourceReaders.csproj", "{B17B8F9D-6832-4215-A388-EC9398E7C071}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Packata.ResourceReaders.Testing", "src\Packata.ResourceReaders.Testing\Packata.ResourceReaders.Testing.csproj", "{7A9C53DD-A0D6-4771-8934-4DE37C10ECAD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +54,14 @@ Global
 		{6F8E7D81-19C5-49F9-9E6C-117947D755ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6F8E7D81-19C5-49F9-9E6C-117947D755ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F8E7D81-19C5-49F9-9E6C-117947D755ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B17B8F9D-6832-4215-A388-EC9398E7C071}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17B8F9D-6832-4215-A388-EC9398E7C071}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B17B8F9D-6832-4215-A388-EC9398E7C071}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B17B8F9D-6832-4215-A388-EC9398E7C071}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A9C53DD-A0D6-4771-8934-4DE37C10ECAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A9C53DD-A0D6-4771-8934-4DE37C10ECAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A9C53DD-A0D6-4771-8934-4DE37C10ECAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A9C53DD-A0D6-4771-8934-4DE37C10ECAD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,11 +26,6 @@ init:
 - cmd: RefreshEnv.cmd
 - pwsh: Write-Host "Target branch is '$($env:APPVEYOR_REPO_BRANCH)'"
 
-install:
-- ps: |
-    Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile "$env:temp\dotnet-install.ps1"
-    & $env:temp\dotnet-install.ps1 -Architecture x64 -Version '9.0.100' -InstallDir "$env:ProgramFiles\dotnet"
-
 before_build:
 - cmd: gitversion /output buildserver /verbosity Minimal
 - pwsh: Write-Host "Building Packata version $($env:GitVersion_SemVer)"
@@ -57,8 +52,10 @@ build_script:
 test_script:
 - pwsh: |
     $ErrorActionPreference = "Stop"
-    dotnet test src/Packata.Core.Testing -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Include="[Packata.Core]*" /p:Threshold=80 /p:ThresholdType=line /p:CoverletOutput=../../.coverage/coverage.Packata.Core.xml --test-adapter-path:. --logger:Appveyor --no-build --nologo
+    dotnet test src/Packata.Core.Testing -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Packata.*.Testing]*" /p:Threshold=10 /p:ThresholdType=line /p:CoverletOutput=../../.coverage/coverage.Packata.Core.xml --test-adapter-path:. --logger:Appveyor --no-build --nologo
     $globalTestResult = $LastExitCode
+    dotnet test src/Packata.ResourceReaders.Testing -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Packata.*.Testing]*" /p:Threshold=10 /p:ThresholdType=line /p:CoverletOutput=../../.coverage/coverage.Packata.ResourceReaders.xml --test-adapter-path:. --logger:Appveyor --no-build --nologo
+    $globalTestResult += $LastExitCode
     if($globalTestResult -ne 0) { $host.SetShouldExit($globalTestResult) }
 
 - pwsh: |
@@ -68,6 +65,7 @@ test_script:
 
 after_test:
 - dotnet pack src/Packata.Core -p:version="%GitVersion_SemVer%" -c Release --include-symbols --no-build --nologo
+- dotnet pack src/Packata.ResourceReaders -p:version="%GitVersion_SemVer%" -c Release --include-symbols --no-build --nologo
 
 artifacts:
 - path: '**\*.nupkg'

--- a/src/Packata.Core.Testing/Serialization/Json/BaseConverterTests.cs
+++ b/src/Packata.Core.Testing/Serialization/Json/BaseConverterTests.cs
@@ -4,8 +4,6 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using Newtonsoft.Json.Serialization;
 using NUnit.Framework.Internal;
-using Microsoft.Testing.Platform.Extensions.TestFramework;
-using DubUrl.Querying.Dialects.Casters;
 
 namespace Packata.Core.Testing.Serialization.Json;
 

--- a/src/Packata.Core/LiteralConnectionUrl.cs
+++ b/src/Packata.Core/LiteralConnectionUrl.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace Packata.Core;
-internal class LiteralConnectionUrl : IConnection
+public class LiteralConnectionUrl : IConnection
 {
     public string ConnectionUrl { get; }
 

--- a/src/Packata.Core/Packata.Core.csproj
+++ b/src/Packata.Core/Packata.Core.csproj
@@ -5,10 +5,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Description>Packata is a library for consuming Data Package v2 files, enabling seamless access to their referenced data. It supports unpacking, schema validation, and metadata inspection. With a focus on user-friendliness, Packata ensures full compliance with the Data Package specification, making it an essential tool for developers and analysts.</Description>
+  </PropertyGroup>
+  
   <ItemGroup>
-    <PackageReference Include="DubUrl" Version="0.22.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="PocketCsvReader" Version="2.27.10" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 

--- a/src/Packata.Core/PathHandling/HttpPath.cs
+++ b/src/Packata.Core/PathHandling/HttpPath.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace Packata.Core.PathHandling;
-internal class HttpPath : IPath
+public class HttpPath : IPath
 {
     public HttpClient Client { get; }
     public string Path { get; }

--- a/src/Packata.Core/PathHandling/LocalPath.cs
+++ b/src/Packata.Core/PathHandling/LocalPath.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Packata.Core.Testing.PathHandling;
 
 namespace Packata.Core.PathHandling;
-internal class LocalPath : IPath
+public class LocalPath : IPath
 {
     public string Root { get; }
     public string Path { get; }
@@ -19,7 +19,7 @@ internal class LocalPath : IPath
     public LocalPath(string root, string path)
         : this(new FileSystem(), root, path) { }
 
-    protected internal LocalPath(IFileSystem fileSystem, string root, string path)
+    public LocalPath(IFileSystem fileSystem, string root, string path)
         => (FileSystem, Root, Path) = (fileSystem, root, path);
 
     public bool Exists()

--- a/src/Packata.Core/Resource.cs
+++ b/src/Packata.Core/Resource.cs
@@ -21,16 +21,4 @@ public partial class Resource
     /// The root path of the data package.
     /// </summary> 
     public string RootPath { get; }
-
-
-    /// <summary>
-    /// Returns a IDataReader for the resource.
-    /// </summary>
-    /// <returns>An IDataReader</returns>
-    public IDataReader ToDataReader()
-    {
-        var factory = new ResourceReaderFactory();
-        var reader = factory.Create(this);
-        return reader.ToDataReader(this);
-    }
 }

--- a/src/Packata.Core/ResourceReading/DateTimeFormatConverter.cs
+++ b/src/Packata.Core/ResourceReading/DateTimeFormatConverter.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace Packata.Core.ResourceReading;
-internal class DateTimeFormatConverter
+public class DateTimeFormatConverter
 {
     // Mapping dictionary for C-style to .NET-style format specifiers
     private static readonly Dictionary<string, string> FormatMap = new()

--- a/src/Packata.Core/ResourceReading/IResourceReaderFactory.cs
+++ b/src/Packata.Core/ResourceReading/IResourceReaderFactory.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace Packata.Core.ResourceReading;
-internal interface IResourceReaderFactory
+public interface IResourceReaderFactory
 {
     void AddOrReplaceReader(string profile, IResourceReaderBuilder builder);
     IResourceReader Create(Resource resource);

--- a/src/Packata.Core/RuntimeTypeMapper.cs
+++ b/src/Packata.Core/RuntimeTypeMapper.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace Packata.Core;
-internal class RuntimeTypeMapper
+public class RuntimeTypeMapper
 {
     private struct TypeFormat : IEquatable<TypeFormat>
     {

--- a/src/Packata.Core/Serialization/Yaml/CategoriesConverter.cs
+++ b/src/Packata.Core/Serialization/Yaml/CategoriesConverter.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection.Emit;
-using PocketCsvReader;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;

--- a/src/Packata.ResourceReaders.Testing/Packata.ResourceReaders.Testing.csproj
+++ b/src/Packata.ResourceReaders.Testing/Packata.ResourceReaders.Testing.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Chrononuensis" Version="0.23.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="DotNet.ReproducibleBuilds" Version="1.2.25">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Packata.Core\Packata.Core.csproj" />
+    <ProjectReference Include="..\Packata.ResourceReaders\Packata.ResourceReaders.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Packata.ResourceReaders.Testing/ResourceReaderFactoryTests.cs
+++ b/src/Packata.ResourceReaders.Testing/ResourceReaderFactoryTests.cs
@@ -5,9 +5,11 @@ using System.Text;
 using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
+using Packata.Core;
 using Packata.Core.ResourceReading;
+using Packata.ResourceReaders.Tabular;
 
-namespace Packata.Core.Testing.ResourceReading;
+namespace Packata.ResourceReaders.Testing;
 public class ResourceReaderFactoryTests
 {
     [Test]
@@ -17,7 +19,7 @@ public class ResourceReaderFactoryTests
 
         var factory = new ResourceReaderFactory();
         var reader = factory.Create(resource);
-        Assert.That(reader, Is.InstanceOf<TableDelimitedReader>());
+        Assert.That(reader, Is.InstanceOf<DelimitedReader>());
     }
 
     [Test]
@@ -27,7 +29,7 @@ public class ResourceReaderFactoryTests
 
         var factory = new ResourceReaderFactory();
         var reader = factory.Create(resource);
-        Assert.That(reader, Is.InstanceOf<TableDatabaseReader>());
+        Assert.That(reader, Is.InstanceOf<DatabaseReader>());
     }
 
     [Test]

--- a/src/Packata.ResourceReaders.Testing/ResourceTests.cs
+++ b/src/Packata.ResourceReaders.Testing/ResourceTests.cs
@@ -4,10 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Packata.Core;
 using Packata.Core.PathHandling;
 using RichardSzalay.MockHttp;
 
-namespace Packata.Core.Testing;
+namespace Packata.ResourceReaders.Testing;
 public class ResourceTests
 {
     [Test]

--- a/src/Packata.ResourceReaders.Testing/Tabular/DatabaseReaderBuilderTests.cs
+++ b/src/Packata.ResourceReaders.Testing/Tabular/DatabaseReaderBuilderTests.cs
@@ -7,13 +7,11 @@ using System.Threading.Tasks;
 using DubUrl.Registering;
 using Moq;
 using NUnit.Framework;
-using Packata.Core.PathHandling;
-using Packata.Core.ResourceReading;
-using Packata.Core.Testing.PathHandling;
-using PocketCsvReader;
+using Packata.Core;
+using Packata.ResourceReaders.Tabular;
 
-namespace Packata.Core.Testing.ResourceReading;
-public class TableDatabaseReaderBuilderTests
+namespace Packata.ResourceReaders.Testing.Tabular;
+public class DatabaseReaderBuilderTests
 {
     private class FakeDbProviderFactory : DbProviderFactory
     {
@@ -34,12 +32,12 @@ public class TableDatabaseReaderBuilderTests
         var discoverMock = new Mock<IProviderFactoriesDiscoverer>();
         discoverMock.Setup(x => x.Execute()).Returns(new[] { typeof(FakeDbProviderFactory) });
 
-        var builder = new TableDatabaseReaderBuilder(new ProviderFactoriesRegistrator(discoverMock.Object));
+        var builder = new DatabaseReaderBuilder(new ProviderFactoriesRegistrator(discoverMock.Object));
         builder.Configure(resource);
         var reader = builder.Build();
 
         discoverMock.Verify(x => x.Execute(), Times.Once);
         Assert.That(reader, Is.Not.Null);
-        Assert.That(reader, Is.InstanceOf<TableDatabaseReader>());
+        Assert.That(reader, Is.InstanceOf<DatabaseReader>());
     }
 }

--- a/src/Packata.ResourceReaders.Testing/Tabular/DatabaseReaderTests.cs
+++ b/src/Packata.ResourceReaders.Testing/Tabular/DatabaseReaderTests.cs
@@ -5,22 +5,17 @@ using System.Data.Common;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Chrononuensis;
 using DubUrl;
 using DubUrl.Mapping;
 using DubUrl.Querying.Dialects;
 using DubUrl.Querying.Dialects.Renderers;
 using Moq;
 using NUnit.Framework;
-using Packata.Core.PathHandling;
-using Packata.Core.ResourceReading;
-using Packata.Core.Testing.PathHandling;
-using PocketCsvReader;
-using PocketCsvReader.Configuration;
-using RichardSzalay.MockHttp;
+using Packata.Core;
+using Packata.ResourceReaders.Tabular;
 
-namespace Packata.Core.Testing.ResourceReading;
-public class TableDatabaseReaderTests
+namespace Packata.ResourceReaders.Testing.Tabular;
+public class DatabaseReaderTests
 {
     [Test]
     public void ToDataReader_TableDefined_ExpectedCommand()
@@ -52,7 +47,7 @@ public class TableDatabaseReaderTests
         var mockFactory = new Mock<ConnectionUrlFactory>(new SchemeMapperBuilder());
         mockFactory.Setup(x => x.Instantiate(It.IsAny<string>())).Returns(mockConnectionUrl.Object);
 
-        var reader = new TableDatabaseReader(mockFactory.Object);
+        var reader = new DatabaseReader(mockFactory.Object);
         var dataReader = reader.ToDataReader(resource);
 
         Assert.That(dataReader, Is.Not.Null);

--- a/src/Packata.ResourceReaders.Testing/Tabular/DelimitedReaderBuilderTests.cs
+++ b/src/Packata.ResourceReaders.Testing/Tabular/DelimitedReaderBuilderTests.cs
@@ -5,13 +5,15 @@ using System.Text;
 using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
+using Packata.Core;
 using Packata.Core.PathHandling;
 using Packata.Core.ResourceReading;
 using Packata.Core.Testing.PathHandling;
+using Packata.ResourceReaders.Tabular;
 using PocketCsvReader;
 
-namespace Packata.Core.Testing.ResourceReading;
-public class TableDelimitedReaderBuilderTests
+namespace Packata.ResourceReaders.Testing.Tabular;
+public class DelimitedReaderBuilderTests
 {
     private static LocalPath GetPath(string content)
     {
@@ -31,7 +33,7 @@ public class TableDelimitedReaderBuilderTests
             Name = "my-resource",
             Dialect = new TableDelimitedDialect() { Delimiter = ';', LineTerminator = "\n" }
         };
-        var builder = new TableDelimitedReaderBuilder();
+        var builder = new DelimitedReaderBuilder();
         builder.Configure(resource);
         var reader = builder.Build();
 
@@ -80,7 +82,7 @@ public class TableDelimitedReaderBuilderTests
             ]
             }
         };
-        var builder = new TableDelimitedReaderBuilder();
+        var builder = new DelimitedReaderBuilder();
         builder.Configure(resource);
         var reader = builder.Build();
 

--- a/src/Packata.ResourceReaders.Testing/Tabular/DelimitedReaderTests.cs
+++ b/src/Packata.ResourceReaders.Testing/Tabular/DelimitedReaderTests.cs
@@ -6,15 +6,16 @@ using System.Threading.Tasks;
 using Chrononuensis;
 using Moq;
 using NUnit.Framework;
+using Packata.Core;
 using Packata.Core.PathHandling;
-using Packata.Core.ResourceReading;
 using Packata.Core.Testing.PathHandling;
+using Packata.ResourceReaders.Tabular;
 using PocketCsvReader;
 using PocketCsvReader.Configuration;
 using RichardSzalay.MockHttp;
 
-namespace Packata.Core.Testing.ResourceReading;
-public class TableDelimitedReaderTests
+namespace Packata.ResourceReaders.Testing.Tabular;
+public class DelimitedReaderTests
 {
     private static IEnumerable<IPath> GetPaths()
     {
@@ -36,7 +37,7 @@ public class TableDelimitedReaderTests
     {
         var resource = new Resource() { Paths = [path], Type = "table", Name = "my-resource" };
         var csvReader = new CsvReaderBuilder().WithDialect(d => d.WithHeader()).Build();
-        var reader = new TableDelimitedReader(csvReader);
+        var reader = new DelimitedReader(csvReader);
         var dataReader = reader.ToDataReader(resource);
 
         Assert.That(dataReader, Is.Not.Null);
@@ -81,7 +82,7 @@ public class TableDelimitedReaderTests
                 ]
             }
         };
-        var builder = new TableDelimitedReaderBuilder();
+        var builder = new DelimitedReaderBuilder();
         builder.Register("year", typeof(int));
         builder.Register("yearmonth", typeof(YearMonth));
         builder.Configure(resource);
@@ -125,7 +126,7 @@ public class TableDelimitedReaderTests
                 ]
             }
         };
-        var builder = new TableDelimitedReaderBuilder();
+        var builder = new DelimitedReaderBuilder();
         builder.Register("year", typeof(int));
         builder.Register("yearmonth", typeof(YearMonth));
         builder.Configure(resource);

--- a/src/Packata.ResourceReaders.Testing/TabularReaderFactoryTests.cs
+++ b/src/Packata.ResourceReaders.Testing/TabularReaderFactoryTests.cs
@@ -5,18 +5,20 @@ using System.Text;
 using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
+using Packata.Core;
 using Packata.Core.ResourceReading;
+using Packata.ResourceReaders.Tabular;
 using PocketCsvReader;
 
-namespace Packata.Core.Testing.ResourceReading;
-public class TableReaderFactoryTests
+namespace Packata.ResourceReaders.Testing;
+public class TabularReaderFactoryTests
 {
     [Test]
     public void Create_WithTableDelimited_ReturnsTableDelimitedReader()
     {
-        var factory = new TableReaderFactory();
+        var factory = new TabularReaderFactory();
         var reader = factory.Create(new Resource() { Type = "table", Dialect = new TableDelimitedDialect() { Type = "delimited"} });
-        Assert.That(reader, Is.InstanceOf<TableDelimitedReader>());
+        Assert.That(reader, Is.InstanceOf<DelimitedReader>());
     }
 
     [Test]
@@ -24,12 +26,12 @@ public class TableReaderFactoryTests
     {
         var builder = new Mock<IResourceReaderBuilder>();
         builder.Setup(x => x.Configure(It.IsAny<Resource>()));
-        builder.Setup(x => x.Build()).Returns(new TableDelimitedReader(new CsvReader()));
+        builder.Setup(x => x.Build()).Returns(new DelimitedReader(new CsvReader()));
 
-        var factory = new TableReaderFactory();
-        factory.AddOrReplaceReader(TableReaderFactory.Delimited, builder.Object);
+        var factory = new TabularReaderFactory();
+        factory.AddOrReplaceReader(TabularReaderFactory.Delimited, builder.Object);
         var reader = factory.Create(new Resource() { Type = "table", Dialect = new TableDelimitedDialect() { Type = "delimited", Delimiter=';' } });
-        Assert.That(reader, Is.InstanceOf<TableDelimitedReader>());
+        Assert.That(reader, Is.InstanceOf<DelimitedReader>());
 
         builder.Verify(x => x.Configure(It.Is<Resource>(r => (r.Dialect as TableDelimitedDialect)!.Delimiter == ';')), Times.Once);
         builder.Verify(x => x.Build(), Times.Once);
@@ -43,12 +45,12 @@ public class TableReaderFactoryTests
         builder.Setup(x => x.Configure(It.IsAny<Resource>()));
         builder.Setup(x => x.Build()).Returns(structuredReader.Object);
 
-        var factory = new TableReaderFactory();
-        factory.AddOrReplaceReader(TableReaderFactory.Structured, builder.Object);
-        factory.SetHeuristic(r => r.Dialect?.Type ?? TableReaderFactory.Structured);
+        var factory = new TabularReaderFactory();
+        factory.AddOrReplaceReader(TabularReaderFactory.Structured, builder.Object);
+        factory.SetHeuristic(r => r.Dialect?.Type ?? TabularReaderFactory.Structured);
 
         var reader = factory.Create(new Resource() { Type = "table", Dialect = new TableDelimitedDialect() { Type = "delimited", Delimiter = ';' } });
-        Assert.That(reader, Is.InstanceOf<TableDelimitedReader>());
+        Assert.That(reader, Is.InstanceOf<DelimitedReader>());
 
         reader = factory.Create(new Resource() { Type = "table" });
         Assert.That(reader, Is.EqualTo(structuredReader.Object));

--- a/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
+++ b/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Description>Packata is a library for consuming Data Package v2 files. The `Packata.ResourceReaders` package specializes in providing read access to resource files using common patterns, such as `IDataReader`, ensuring seamless data retrieval and processing.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Packata.Core\Packata.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DubUrl" Version="0.22.6" />
+    <PackageReference Include="PocketCsvReader" Version="2.27.10" />
+  </ItemGroup>
+
+</Project>

--- a/src/Packata.ResourceReaders/ResourceExtensions.cs
+++ b/src/Packata.ResourceReaders/ResourceExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Packata.Core;
+
+namespace Packata.ResourceReaders;
+public static class ResourceExtensions
+{
+    /// <summary>
+    /// Returns a IDataReader for the resource.
+    /// </summary>
+    /// <returns>An IDataReader</returns>
+    public static IDataReader ToDataReader(this Resource resource)
+    {
+        var factory = new ResourceReaderFactory();
+        var reader = factory.Create(resource);
+        return reader.ToDataReader(resource);
+    }
+}

--- a/src/Packata.ResourceReaders/ResourceReaderFactory.cs
+++ b/src/Packata.ResourceReaders/ResourceReaderFactory.cs
@@ -3,16 +3,17 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using static System.Runtime.InteropServices.JavaScript.JSType;
+using Packata.Core;
+using Packata.Core.ResourceReading;
 
-namespace Packata.Core.ResourceReading;
+namespace Packata.ResourceReaders;
 public class ResourceReaderFactory
 {
     private Dictionary<string, IResourceReaderFactory> Factories { get; } = [];
 
     public ResourceReaderFactory()
     {
-        Factories.Add("table", new TableReaderFactory());
+        Factories.Add("table", new TabularReaderFactory());
     }
 
     public void AddOrReplaceReader(string type, string subType, IResourceReaderBuilder builder)

--- a/src/Packata.ResourceReaders/Tabular/DatabaseReader.cs
+++ b/src/Packata.ResourceReaders/Tabular/DatabaseReader.cs
@@ -5,23 +5,25 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using DubUrl;
+using Packata.Core;
+using Packata.Core.ResourceReading;
 
-namespace Packata.Core.ResourceReading;
-internal class TableDatabaseReader : IResourceReader
+namespace Packata.ResourceReaders.Tabular;
+internal class DatabaseReader : IResourceReader
 {
     private readonly ConnectionUrlFactory connectionUrlFactory;
 
-    public TableDatabaseReader(string rootPath)
+    public DatabaseReader(string rootPath)
         : this(new ConnectionUrlFactory(new DubUrl.Mapping.SchemeMapperBuilder(rootPath)))
     { }
 
-    public TableDatabaseReader(ConnectionUrlFactory connectionUrlFactory)
+    public DatabaseReader(ConnectionUrlFactory connectionUrlFactory)
         => this.connectionUrlFactory = connectionUrlFactory;
 
     public IDataReader ToDataReader(Resource resource)
     {
         var url = resource.Connection?.ConnectionUrl ?? throw new ArgumentException("Connection is not specified", nameof(resource));
-        var dialect = (resource.Dialect as TableDatabaseDialect) ?? throw new InvalidOperationException();
+        var dialect = resource.Dialect as TableDatabaseDialect ?? throw new InvalidOperationException();
 
         var connectionUrl = connectionUrlFactory.Instantiate(url);
         using (var connection = connectionUrl.Open())

--- a/src/Packata.ResourceReaders/Tabular/DatabaseReaderBuilder.cs
+++ b/src/Packata.ResourceReaders/Tabular/DatabaseReaderBuilder.cs
@@ -1,26 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Linq;
-using System.Reflection.Emit;
-using System.Text;
 using System.Threading.Tasks;
-using DubUrl;
 using DubUrl.Registering;
+using Packata.Core;
+using Packata.Core.ResourceReading;
 
-namespace Packata.Core.ResourceReading;
-public class TableDatabaseReaderBuilder : IResourceReaderBuilder
+namespace Packata.ResourceReaders.Tabular;
+public class DatabaseReaderBuilder : IResourceReaderBuilder
 {
     private readonly ProviderFactoriesRegistrator providerFactories;
     private string? RootPath { get; set; }
 
-    public TableDatabaseReaderBuilder()
+    public DatabaseReaderBuilder()
         : this(new ProviderFactoriesRegistrator())
     { }
 
-    public TableDatabaseReaderBuilder(ProviderFactoriesRegistrator providerFactories)
+    public DatabaseReaderBuilder(ProviderFactoriesRegistrator providerFactories)
         => this.providerFactories = providerFactories;
 
     public void Configure(Resource resource)
@@ -30,5 +26,5 @@ public class TableDatabaseReaderBuilder : IResourceReaderBuilder
     }
 
     public IResourceReader Build()
-        => new TableDatabaseReader(RootPath ?? throw new InvalidOperationException());
+        => new DatabaseReader(RootPath ?? throw new InvalidOperationException());
 }

--- a/src/Packata.ResourceReaders/Tabular/DelimitedReader.cs
+++ b/src/Packata.ResourceReaders/Tabular/DelimitedReader.cs
@@ -5,15 +5,16 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using PocketCsvReader;
-using PocketCsvReader.Configuration;
+using Packata.Core;
+using Packata.Core.ResourceReading;
 
-namespace Packata.Core.ResourceReading;
-internal class TableDelimitedReader : IResourceReader
+namespace Packata.ResourceReaders.Tabular;
+internal class DelimitedReader : IResourceReader
 {
     private CsvReader CsvReader { get; }
 
-    public TableDelimitedReader(CsvReader csvReader)
-        => (CsvReader) = (csvReader);
+    public DelimitedReader(CsvReader csvReader)
+        => CsvReader = csvReader;
 
     public IDataReader ToDataReader(Resource resource)
     {

--- a/src/Packata.ResourceReaders/Tabular/DelimitedReaderBuilder.cs
+++ b/src/Packata.ResourceReaders/Tabular/DelimitedReaderBuilder.cs
@@ -6,11 +6,12 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection.Emit;
 using System.Text;
-using System.Threading.Tasks;
+using Packata.Core;
+using Packata.Core.ResourceReading;
 using PocketCsvReader.Configuration;
 
-namespace Packata.Core.ResourceReading;
-public class TableDelimitedReaderBuilder : IResourceReaderBuilder
+namespace Packata.ResourceReaders.Tabular;
+public class DelimitedReaderBuilder : IResourceReaderBuilder
 {
     private CsvReaderBuilder? CsvReaderBuilder { get; set; }
     private RuntimeTypeMapper RuntimeTypes { get; }  = new();
@@ -30,7 +31,7 @@ public class TableDelimitedReaderBuilder : IResourceReaderBuilder
     {
         if (CsvReaderBuilder is null)
             throw new InvalidOperationException("Builder not configured");
-        return new TableDelimitedReader(CsvReaderBuilder.Build());
+        return new DelimitedReader(CsvReaderBuilder.Build());
     }
 
     protected virtual CsvReaderBuilder ConfigureBuilder(Resource resource)
@@ -156,9 +157,10 @@ public class TableDelimitedReaderBuilder : IResourceReaderBuilder
             resourceBuilder.WithEncoding(resource.Encoding);
         }
 
-        var csvReaderBuilder = new CsvReaderBuilder().WithDialect(dialectBuilder);
+        var csvReaderBuilder = new CsvReaderBuilder()
+                                    .WithDialect(dialectBuilder)
+                                    .WithResource(resourceBuilder);
         csvReaderBuilder = schemaBuilder is not null ? csvReaderBuilder.WithSchema(schemaBuilder) : csvReaderBuilder;
-        csvReaderBuilder = resourceBuilder is not null ? csvReaderBuilder.WithResource(resourceBuilder) : csvReaderBuilder;
         return csvReaderBuilder;
     }
 }

--- a/src/Packata.ResourceReaders/TabularReaderFactory.cs
+++ b/src/Packata.ResourceReaders/TabularReaderFactory.cs
@@ -3,9 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Packata.Core;
+using Packata.Core.ResourceReading;
+using Packata.ResourceReaders.Tabular;
 
-namespace Packata.Core.ResourceReading;
-internal class TableReaderFactory : IResourceReaderFactory
+namespace Packata.ResourceReaders;
+internal class TabularReaderFactory : IResourceReaderFactory
 {
     public const string Delimited = "delimited";
     public const string Structured = "structured";
@@ -25,10 +28,10 @@ internal class TableReaderFactory : IResourceReaderFactory
     public void SetHeuristic(Func<Resource, string> heuristic)
         => Heuristic = heuristic;
 
-    public TableReaderFactory()
+    public TabularReaderFactory()
     {
-        AddOrReplaceReader(Delimited, new TableDelimitedReaderBuilder());
-        AddOrReplaceReader(Database, new TableDatabaseReaderBuilder());
+        AddOrReplaceReader(Delimited, new DelimitedReaderBuilder());
+        AddOrReplaceReader(Database, new DatabaseReaderBuilder());
         Heuristic = resource => resource.Dialect?.Type ?? Delimited;
     }
 


### PR DESCRIPTION
Refactored Packata to separate concerns, improving modularity and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a resource reading library that enhances support for data package files and expands overall functionality.
  
- **Refactor**
  - Made key API components publicly accessible and streamlined reader implementations with clearer naming.
  - Updated class and method names to reflect new functionality and organization.

- **Tests**
  - Reorganized test suites with updated coverage criteria to include the new resource reader functionality.
  - Adjusted assertions in tests to align with new reader types.

- **Chores**
  - Optimized build, packaging, and testing processes to streamline installation and overall workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->