### PR TITLE
feat: handle multi-file resources without repeated headers

### DIFF
--- a/src/Packata.Core/TableDelimitedDialect.cs
+++ b/src/Packata.Core/TableDelimitedDialect.cs
@@ -68,6 +68,19 @@ public class TableDelimitedDialect : TableDialect
     public string? HeaderJoin { get; set; } = " ";
 
     /// <summary>
+    /// Gets or sets a value indicating whether the header row is present in every file
+    /// or only in the first file of a multi-file resource.
+    /// When set to <c>true</c> (default), the header is expected in each file.
+    /// When set to <c>false</c>, only the first file is expected to contain the header row.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// HeaderRepeat = false; // Header only exists in the first file
+    /// </code>
+    /// </example>
+    public bool HeaderRepeat { get; set; } = true;
+
+    /// <summary>
     /// A string representing a sequence to be interpreted as a null value.
     /// Default is undefined.
     /// </summary>

--- a/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
+++ b/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="DubUrl" Version="0.27.0" />
     <PackageReference Include="Parquet.Net" Version="5.1.1" />
-    <PackageReference Include="PocketCsvReader" Version="2.28.0" />
+    <PackageReference Include="PocketCsvReader" Version="2.29.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Packata.ResourceReaders/Tabular/DelimitedReaderBuilder.cs
+++ b/src/Packata.ResourceReaders/Tabular/DelimitedReaderBuilder.cs
@@ -49,6 +49,7 @@ public class DelimitedReaderBuilder : IResourceReaderBuilder
                 .WithHeader(dialect.Header)
                 .WithHeaderJoin(dialect.HeaderJoin ?? "")
                 .WithHeaderRows(dialect.HeaderRows?.ToArray() ?? [])
+                .WithHeaderRepeat(dialect.HeaderRepeat)
                 .WithCommentChar(dialect.CommentChar)
                 .WithCommentRows(dialect.CommentRows?.ToArray() ?? [])
                 .WithSkipInitialSpace(dialect.SkipInitialSpace);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable option for handling header rows in multi-file table-delimited resources, allowing headers to be repeated on every file or just the first.

- **Tests**
  - Updated tests to validate the new multi-file processing behavior and ensure the correct reading of simplified data structures.

- **Chores**
  - Upgraded the CSV reader dependency to enhance performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->