### PR TITLE
chore: bump PocketCsvReader from 2.32.2 to 2.33.3

### DIFF
--- a/src/Packata.Provisioners/Packata.Provisioners.csproj
+++ b/src/Packata.Provisioners/Packata.Provisioners.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DubUrl.BulkCopy" Version="0.27.9" />
-    <PackageReference Include="DubUrl.Schema" Version="0.27.1" />
+    <PackageReference Include="DubUrl.BulkCopy" Version="0.27.10" />
+    <PackageReference Include="DubUrl.Schema" Version="0.27.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
+++ b/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="DubUrl" Version="0.27.10" />
     <PackageReference Include="Parquet.Net" Version="5.1.1" />
-    <PackageReference Include="PocketCsvReader" Version="2.32.2" />
+    <PackageReference Include="PocketCsvReader" Version="2.33.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded several package dependencies to their latest versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->