### PR TITLE
chore: bump DubUrl, DubUrl.Schema and DubUrl.BulkCopy from 0.27.11 to 2.27.15

### DIFF
--- a/src/Packata.Provisioners/Packata.Provisioners.csproj
+++ b/src/Packata.Provisioners/Packata.Provisioners.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DubUrl.BulkCopy" Version="0.27.11" />
-    <PackageReference Include="DubUrl.Schema" Version="0.27.10" />
+    <PackageReference Include="DubUrl.BulkCopy" Version="0.27.15" />
+    <PackageReference Include="DubUrl.Schema" Version="0.27.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
+++ b/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DubUrl" Version="0.27.11" />
+    <PackageReference Include="DubUrl" Version="0.27.15" />
     <PackageReference Include="ExcelDataReader" Version="3.7.0" />
     <PackageReference Include="Parquet.Net" Version="5.1.1" />
     <PackageReference Include="PocketCsvReader" Version="2.35.4" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated underlying package dependencies to newer versions for improved stability and compatibility. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->