### PR TITLE
chore : bump DubUrl (incl Schema & BulkCopy) from 0.27.15 to 0.27.17

### DIFF
--- a/src/Packata.Provisioners/Packata.Provisioners.csproj
+++ b/src/Packata.Provisioners/Packata.Provisioners.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DubUrl.BulkCopy" Version="0.27.15" />
-    <PackageReference Include="DubUrl.Schema" Version="0.27.15" />
+    <PackageReference Include="DubUrl.BulkCopy" Version="0.27.17" />
+    <PackageReference Include="DubUrl.Schema" Version="0.27.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
+++ b/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DubUrl" Version="0.27.15" />
+    <PackageReference Include="DubUrl" Version="0.27.17" />
     <PackageReference Include="ExcelDataReader" Version="3.7.0" />
     <PackageReference Include="Parquet.Net" Version="5.1.1" />
     <PackageReference Include="PocketCsvReader" Version="2.35.4" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package dependencies to newer versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->