### PR TITLE
feat: lazy opening of streams when paths are multiple

### DIFF
--- a/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
+++ b/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="DubUrl" Version="0.27.17" />
     <PackageReference Include="ExcelDataReader" Version="3.7.0" />
     <PackageReference Include="Parquet.Net" Version="5.1.1" />
-    <PackageReference Include="PocketCsvReader" Version="2.35.4" />
+    <PackageReference Include="PocketCsvReader" Version="2.36.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Packata.ResourceReaders/Tabular/CsvReaderExtensions.cs
+++ b/src/Packata.ResourceReaders/Tabular/CsvReaderExtensions.cs
@@ -15,8 +15,10 @@ internal static class CsvReaderExtensions
             throw new InvalidOperationException(
                 "The resource does not contain any paths, but at least one is required to create a DataReader.");
 
-        var streams = streamFactories.Select(factory => factory().ConfigureAwait(false).GetAwaiter().GetResult()).ToArray();
-        return reader.ToDataReader(streams);
+        var syncFuncs = streamFactories.Select(
+            asyncFunc => (Func<Stream>)(() => asyncFunc().ConfigureAwait(false).GetAwaiter().GetResult())
+        );  
+        return reader.ToDataReader(syncFuncs);
     }
 
     public static IDataReader ToDataReader(this CsvReader reader, Func<Task<Stream>> streamFactory)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded a package dependency to the latest version.

- **Refactor**
  - Improved the handling of asynchronous stream factories to defer execution and enhance lazy evaluation behavior. 

No changes to public interfaces or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->