### PR TITLE
fix: don't generate any file if the delta schema is empty

### DIFF
--- a/package-delta-schemas.ps1
+++ b/package-delta-schemas.ps1
@@ -18,7 +18,7 @@ $dir = ".\.schemas"
 foreach ($schema in $schemas) {
     try {
         Write-Host "Generating schema for $($schema.Class)..."
-        schemathief delta -a $assemblyPath -c $schema.Class -b $schema.Url -x "paths|profile" | Out-File -Encoding UTF8 -FilePath $schema.Output
+        schemathief delta -a $assemblyPath -c $schema.Class -b $schema.Url -x "paths|profile" -o $schema.Output
     } catch {
         Write-Error $schema.Error
         exit 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated script to use a direct output option for schema generation, improving output handling. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->