### PR TITLE
feat: add property "kind" to resources and infer it from "paths"

### DIFF
--- a/src/Packata.Core.Testing/Serialization/ExtensionSerializerTests.cs
+++ b/src/Packata.Core.Testing/Serialization/ExtensionSerializerTests.cs
@@ -53,6 +53,21 @@ public class ExtensionSerializerTests
         });
     }
 
+
+    [TestCaseSource(nameof(GetData))]
+    public void Deserialize_ResourceKind_Success((Stream Stream, IDataPackageSerializer Serializer) value)
+    {
+        using var streamReader = new StreamReader(value.Stream);
+        var dataPackage = value.Serializer.Deserialize(streamReader, new LocalDirectoryDataPackageContainer(), new StorageProvider());
+        Assert.That(dataPackage.Resources, Is.Not.Null);
+        Assert.That(dataPackage.Resources, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(dataPackage.Resources[0].Kind, Is.EqualTo("local"));
+        });
+    }
+
+
     [TestCaseSource(nameof(GetData))]
     public void Deserialize_Metrics_Success((Stream Stream, IDataPackageSerializer Serializer) value)
     {

--- a/src/Packata.Core.Testing/Serialization/Json/Resources/extension.json
+++ b/src/Packata.Core.Testing/Serialization/Json/Resources/extension.json
@@ -13,6 +13,7 @@
             "name": "measures",
             "path": "sensor_measures.csv",
             "type": "table",
+            "kind": "local",
             "$schema": "https://packata.dev/profiles/1.0/dataresource.json",
             "title": "Sensors' temperatures & hygrometry",
             "format": "csv",

--- a/src/Packata.Core.Testing/Serialization/Yaml/Resources/extension.yaml
+++ b/src/Packata.Core.Testing/Serialization/Yaml/Resources/extension.yaml
@@ -10,6 +10,7 @@ resources:
 - name: measures
   path: sensor_measures.csv
   type: table
+  kind: local
   "$schema": https://packata.dev/profiles/1.0/dataresource.json
   title: "Sensors' temperatures & hygrometry"
   format: csv

--- a/src/Packata.Core/Resource.Props.cs
+++ b/src/Packata.Core/Resource.Props.cs
@@ -48,6 +48,13 @@ public partial class Resource
     public string? Type { get; set; }
 
     /// <summary>
+    /// The type of the resource.
+    /// </summary>
+    /// <remarks>Specifies the nature of the resource, such as "table".</remarks>
+    /// <example>"virtual", "local", "service", "remote"</example>
+    public string? Kind { get; set; }
+
+    /// <summary>
     /// The file format of the resource.
     /// </summary>
     /// <remarks>Should be a file extension such as "csv" or "json".</remarks>

--- a/src/Packata.ResourceReaders.Testing/Inference/FormatBasedDialectInferenceTests.cs
+++ b/src/Packata.ResourceReaders.Testing/Inference/FormatBasedDialectInferenceTests.cs
@@ -15,8 +15,11 @@ namespace Packata.ResourceReaders.Testing.Inference
 
             var result = inference.TryInfer(resource, out var dialect);
 
-            Assert.That(result, Is.False);
-            Assert.That(dialect, Is.Null);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.False);
+                Assert.That(dialect, Is.Null);
+            }
         }
 
         [Test]
@@ -33,11 +36,16 @@ namespace Packata.ResourceReaders.Testing.Inference
 
             Assert.That(result, Is.True);
             Assert.That(dialect, Is.Not.Null);
-            Assert.That(dialect!.Delimiter, Is.EqualTo(delimiter));
-            Assert.That(dialect.QuoteChar, Is.EqualTo(quoteChar));
-            Assert.That(dialect.EscapeChar, Is.EqualTo(escapeChar));
-            Assert.That(dialect.DoubleQuote, Is.EqualTo(doubleQuote));
-            Assert.That(dialect.LineTerminator, Is.EqualTo(lineTerminator));
+            Assert.That(dialect, Is.TypeOf<TableDelimitedDialect>());
+            var tdDialect = (TableDelimitedDialect)dialect;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(tdDialect.Delimiter, Is.EqualTo(delimiter));
+                Assert.That(tdDialect.QuoteChar, Is.EqualTo(quoteChar));
+                Assert.That(tdDialect.EscapeChar, Is.EqualTo(escapeChar));
+                Assert.That(tdDialect.DoubleQuote, Is.EqualTo(doubleQuote));
+                Assert.That(tdDialect.LineTerminator, Is.EqualTo(lineTerminator));
+            }
         }
 
         [Test]
@@ -48,8 +56,11 @@ namespace Packata.ResourceReaders.Testing.Inference
 
             var result = inference.TryInfer(resource, out var dialect);
 
-            Assert.That(result, Is.False);
-            Assert.That(dialect, Is.Null);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.False);
+                Assert.That(dialect, Is.Null);
+            }
         }
     }
 }

--- a/src/Packata.ResourceReaders.Testing/Inference/MediaTypeBasedDialectInferenceTests.cs
+++ b/src/Packata.ResourceReaders.Testing/Inference/MediaTypeBasedDialectInferenceTests.cs
@@ -45,7 +45,9 @@ namespace Packata.ResourceReaders.Testing.Inference
 
             Assert.That(result, Is.True);
             Assert.That(dialect, Is.Not.Null);
-            Assert.That(dialect!.Delimiter, Is.EqualTo(delimiter));
+            Assert.That(dialect, Is.TypeOf<TableDelimitedDialect>());
+            var tdDialect = (TableDelimitedDialect)dialect;
+            Assert.That(tdDialect.Delimiter, Is.EqualTo(delimiter));
         }
 
         [Test]

--- a/src/Packata.ResourceReaders.Testing/Inference/ResourceInferenceServiceTests.cs
+++ b/src/Packata.ResourceReaders.Testing/Inference/ResourceInferenceServiceTests.cs
@@ -46,8 +46,8 @@ namespace Packata.ResourceReaders.Testing.Inference
         {
             var mockDialect = new Mock<IDialectInference>();
             mockDialect
-                .Setup(m => m.TryInfer(It.IsAny<Resource>(), out It.Ref<TableDelimitedDialect?>.IsAny))
-                .Returns((Resource resource, out TableDelimitedDialect? dialect) =>
+                .Setup(m => m.TryInfer(It.IsAny<Resource>(), out It.Ref<TableDialect?>.IsAny))
+                .Returns((Resource resource, out TableDialect? dialect) =>
                 {
                     dialect = new TableDelimitedDialect { Delimiter = ',', QuoteChar = '"', DoubleQuote = true };
                     return true;

--- a/src/Packata.ResourceReaders.Testing/Inference/SchemeBasedKindInferenceTests.cs
+++ b/src/Packata.ResourceReaders.Testing/Inference/SchemeBasedKindInferenceTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Packata.Core;
+using Packata.ResourceReaders.Inference;
+using Packata.Core.Storage;
+using Moq;
+
+namespace Packata.ResourceReaders.Testing.Inference;
+public class SchemeBasedKindInferenceTests
+{
+    private static readonly string[] _remoteArray = ["http", "https"];
+    private static readonly string[] _serviceArray = ["mssql", "pgsql"];
+
+    [Test]
+    [TestCase("data/file.csv", "local")]
+    [TestCase("file.csv", "local")]
+    [TestCase("http://www.data.org/file.csv", "remote")]
+    [TestCase("mssql://192.168.16.45/db", "service")]
+    [TestCase(null, "virtual")]
+    public void TryInfer_Path_Success(string? path, string expected)
+    {
+        bool remote(string value) => (_remoteArray).Any(x => x.Equals(value, StringComparison.OrdinalIgnoreCase));
+        bool service(string value) => (_serviceArray).Any(x => x.Equals(value, StringComparison.OrdinalIgnoreCase));
+        var inference = new SchemeBasedKindInference(remote, service);
+
+        var factory = new PathFactory(Mock.Of<IDataPackageContainer>(), Mock.Of<IStorageProvider>());
+        var resource = path  is null
+            ? new Resource()
+            : new Resource() { Paths = [factory.Create(path)] };
+
+        Assert.That(inference.TryInfer(resource, out var result), Is.True);
+        Assert.That(result, Is.EqualTo(expected));
+    }
+}

--- a/src/Packata.ResourceReaders.Testing/ResourceReaderFactoryTests.cs
+++ b/src/Packata.ResourceReaders.Testing/ResourceReaderFactoryTests.cs
@@ -65,7 +65,7 @@ public class ResourceReaderFactoryTests
                 };
             });
 
-        var factory = new ResourceReaderFactory(ResourceInferenceService.None);
+        var factory = new ResourceReaderFactory(ResourceInferenceServiceBuilder.None);
         var reader = factory.Create(resource);
         Assert.That(resource.Dialect, Is.Null);
 

--- a/src/Packata.ResourceReaders/Inference/BaseCompressionInference.cs
+++ b/src/Packata.ResourceReaders/Inference/BaseCompressionInference.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -13,7 +14,7 @@ public abstract class BaseCompressionInference : ICompressionInference
     protected BaseCompressionInference(IDictionary<string, string> compressionMappings)
         => CompressionMappings = compressionMappings;
 
-    public abstract bool TryInfer(Resource resource, out string? compression);
+    public abstract bool TryInfer(Resource resource, [NotNullWhen(true)] out string? compression);
 
     protected bool TryInferFromExtension(string? extension, out string? compression)
     {

--- a/src/Packata.ResourceReaders/Inference/ExtensionBasedCompressionInference.cs
+++ b/src/Packata.ResourceReaders/Inference/ExtensionBasedCompressionInference.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -16,7 +17,7 @@ public class ExtensionBasedCompressionInference : BaseCompressionInference
         _extractor = extractor;
     }
 
-    public override bool TryInfer(Resource resource, out string? compression)
+    public override bool TryInfer(Resource resource, [NotNullWhen(true)] out string? compression)
     {
         compression = null;
         if (resource.Paths == null || !resource.Paths.Any())

--- a/src/Packata.ResourceReaders/Inference/ExtensionBasedDialectInference.cs
+++ b/src/Packata.ResourceReaders/Inference/ExtensionBasedDialectInference.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,7 +16,7 @@ public class ExtensionBasedDialectInference : FormatBasedDialectInference
         _extractor = extractor;
     }
 
-    public override bool TryInfer(Resource resource, out TableDelimitedDialect? dialect)
+    public override bool TryInfer(Resource resource, [NotNullWhen(true)] out TableDelimitedDialect? dialect)
     {
         dialect = null;
         if (_extractor.TryGetPathExtension(resource.Paths.ToArray(), out var extension))

--- a/src/Packata.ResourceReaders/Inference/ExtensionBasedDialectInference.cs
+++ b/src/Packata.ResourceReaders/Inference/ExtensionBasedDialectInference.cs
@@ -16,7 +16,7 @@ public class ExtensionBasedDialectInference : FormatBasedDialectInference
         _extractor = extractor;
     }
 
-    public override bool TryInfer(Resource resource, [NotNullWhen(true)] out TableDelimitedDialect? dialect)
+    public override bool TryInfer(Resource resource, [NotNullWhen(true)] out TableDialect? dialect)
     {
         dialect = null;
         if (_extractor.TryGetPathExtension(resource.Paths.ToArray(), out var extension))

--- a/src/Packata.ResourceReaders/Inference/ExtensionBasedFormatInference.cs
+++ b/src/Packata.ResourceReaders/Inference/ExtensionBasedFormatInference.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,7 +16,7 @@ public class ExtensionBasedFormatInference : IFormatInference
         _extractor = extractor;
     }
 
-    public bool TryInfer(Resource resource, out string? format)
+    public bool TryInfer(Resource resource, [NotNullWhen(true)] out string? format)
     {
         format = null;
         if (_extractor.TryGetPathExtension(resource.Paths.ToArray(), out var extension))

--- a/src/Packata.ResourceReaders/Inference/FormatBasedDialectInference.cs
+++ b/src/Packata.ResourceReaders/Inference/FormatBasedDialectInference.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -8,10 +9,10 @@ using Packata.Core;
 namespace Packata.ResourceReaders.Inference;
 public class FormatBasedDialectInference : IDialectInference
 {
-    public virtual bool TryInfer(Resource resource, out TableDelimitedDialect? dialect)
+    public virtual bool TryInfer(Resource resource, [NotNullWhen(true)] out TableDelimitedDialect? dialect)
         => TryInferFromFormat(resource.Format, out dialect);
 
-    protected bool TryInferFromFormat(string? format, out TableDelimitedDialect? dialect)
+    protected bool TryInferFromFormat(string? format, [NotNullWhen(true)] out TableDelimitedDialect? dialect)
     {
         dialect = format switch
         {

--- a/src/Packata.ResourceReaders/Inference/FormatBasedDialectInference.cs
+++ b/src/Packata.ResourceReaders/Inference/FormatBasedDialectInference.cs
@@ -9,10 +9,10 @@ using Packata.Core;
 namespace Packata.ResourceReaders.Inference;
 public class FormatBasedDialectInference : IDialectInference
 {
-    public virtual bool TryInfer(Resource resource, [NotNullWhen(true)] out TableDelimitedDialect? dialect)
+    public virtual bool TryInfer(Resource resource, [NotNullWhen(true)] out TableDialect? dialect)
         => TryInferFromFormat(resource.Format, out dialect);
 
-    protected bool TryInferFromFormat(string? format, [NotNullWhen(true)] out TableDelimitedDialect? dialect)
+    protected bool TryInferFromFormat(string? format, [NotNullWhen(true)] out TableDialect? dialect)
     {
         dialect = format switch
         {

--- a/src/Packata.ResourceReaders/Inference/ICompressionInference.cs
+++ b/src/Packata.ResourceReaders/Inference/ICompressionInference.cs
@@ -6,7 +6,5 @@ using System.Threading.Tasks;
 using Packata.Core;
 
 namespace Packata.ResourceReaders.Inference;
-public interface ICompressionInference
-{
-    bool TryInfer(Resource resource, out string? compression);
-}
+public interface ICompressionInference : IInferenceStrategy<string>
+{ }

--- a/src/Packata.ResourceReaders/Inference/IDialectInference.cs
+++ b/src/Packata.ResourceReaders/Inference/IDialectInference.cs
@@ -9,5 +9,5 @@ namespace Packata.ResourceReaders.Inference;
 /// <summary>
 /// Interface for strategies that infer table dialect information from a resource.
 /// </summary>
-public interface IDialectInference : IInferenceStrategy<TableDelimitedDialect>
+public interface IDialectInference : IInferenceStrategy<TableDialect>
 { }

--- a/src/Packata.ResourceReaders/Inference/IFormatInference.cs
+++ b/src/Packata.ResourceReaders/Inference/IFormatInference.cs
@@ -6,7 +6,5 @@ using System.Threading.Tasks;
 using Packata.Core;
 
 namespace Packata.ResourceReaders.Inference;
-public interface IFormatInference
-{
-    bool TryInfer(Resource resource, out string? format);
-}
+public interface IFormatInference : IInferenceStrategy<string>
+{ }

--- a/src/Packata.ResourceReaders/Inference/IInferenceStrategy.cs
+++ b/src/Packata.ResourceReaders/Inference/IInferenceStrategy.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Packata.Core;
+
+namespace Packata.ResourceReaders.Inference;
+public interface IInferenceStrategy<T> : IInferenceStrategy
+{
+    bool TryInfer(Resource resource, [NotNullWhen(true)] out T? value);
+}
+
+public interface IInferenceStrategy
+{ }

--- a/src/Packata.ResourceReaders/Inference/IKindInference.cs
+++ b/src/Packata.ResourceReaders/Inference/IKindInference.cs
@@ -7,7 +7,7 @@ using Packata.Core;
 
 namespace Packata.ResourceReaders.Inference;
 /// <summary>
-/// Interface for strategies that infer table dialect information from a resource.
+/// Interface for strategies that infer kind information from a resource.
 /// </summary>
-public interface IDialectInference : IInferenceStrategy<TableDelimitedDialect>
+public interface IKindInference : IInferenceStrategy<string>
 { }

--- a/src/Packata.ResourceReaders/Inference/MediaTypeBasedCompressionInference.cs
+++ b/src/Packata.ResourceReaders/Inference/MediaTypeBasedCompressionInference.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -12,7 +13,7 @@ public class MediaTypeBasedCompressionInference : BaseCompressionInference
         : base(compressionMappings)
     { }
 
-    public override bool TryInfer(Resource resource, out string? compression)
+    public override bool TryInfer(Resource resource, [NotNullWhen(true)] out string? compression)
     {
         var mediaType = resource.MediaType;
         compression = null;

--- a/src/Packata.ResourceReaders/Inference/MediaTypeBasedDialectInference.cs
+++ b/src/Packata.ResourceReaders/Inference/MediaTypeBasedDialectInference.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -8,7 +9,7 @@ using Packata.Core;
 namespace Packata.ResourceReaders.Inference;
 public class MediaTypeBasedDialectInference : FormatBasedDialectInference
 {
-    public override bool TryInfer(Resource resource, out TableDelimitedDialect? dialect)
+    public override bool TryInfer(Resource resource, [NotNullWhen(true)] out TableDelimitedDialect? dialect)
     {
         var mediaType = resource.MediaType;
         dialect = null;

--- a/src/Packata.ResourceReaders/Inference/MediaTypeBasedDialectInference.cs
+++ b/src/Packata.ResourceReaders/Inference/MediaTypeBasedDialectInference.cs
@@ -9,7 +9,7 @@ using Packata.Core;
 namespace Packata.ResourceReaders.Inference;
 public class MediaTypeBasedDialectInference : FormatBasedDialectInference
 {
-    public override bool TryInfer(Resource resource, [NotNullWhen(true)] out TableDelimitedDialect? dialect)
+    public override bool TryInfer(Resource resource, [NotNullWhen(true)] out TableDialect? dialect)
     {
         var mediaType = resource.MediaType;
         dialect = null;

--- a/src/Packata.ResourceReaders/Inference/MediaTypeBasedFormatInference.cs
+++ b/src/Packata.ResourceReaders/Inference/MediaTypeBasedFormatInference.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -8,7 +9,7 @@ using Packata.Core;
 namespace Packata.ResourceReaders.Inference;
 public class MediaTypeBasedFormatInference : IFormatInference
 {
-    public bool TryInfer(Resource resource, out string? format)
+    public bool TryInfer(Resource resource, [NotNullWhen(true)] out string? format)
     {
         var mediaType = resource.MediaType;
         format = null;

--- a/src/Packata.ResourceReaders/Inference/ResourceInferenceService.cs
+++ b/src/Packata.ResourceReaders/Inference/ResourceInferenceService.cs
@@ -53,9 +53,9 @@ public class ResourceInferenceService : IResourceInferenceService
             string.IsNullOrEmpty
         );
 
-        InferIfUnset<TableDelimitedDialect>(
+        InferIfUnset<TableDialect>(
             resource,
-            r => r.Dialect as TableDelimitedDialect,
+            r => r.Dialect,
             (r, v) => r.Dialect = v,
             _strategies.OfType<IDialectInference>(),
             v => v == null

--- a/src/Packata.ResourceReaders/Inference/ResourceInferenceServiceBuilder.cs
+++ b/src/Packata.ResourceReaders/Inference/ResourceInferenceServiceBuilder.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Text;
+using System.Threading.Tasks;
+using PocketCsvReader.Compression;
+
+namespace Packata.ResourceReaders.Inference;
+internal class ResourceInferenceServiceBuilder
+{
+    private readonly Dictionary<Type, IInferenceStrategy> _strategies = new();
+
+    public ResourceInferenceServiceBuilder AddStrategy<T>(IInferenceStrategy<T> strategy)
+    {
+        var concreteType = strategy.GetType(); // Use concrete type to deduplicate
+        _strategies[concreteType] = (IInferenceStrategy)strategy;
+        return this;
+    }
+
+    public ResourceInferenceService Build()
+        => new (_strategies.Values);
+
+    private static readonly IDictionary<string, string> _compressionMappings = GetCompressionMappings();
+    private static Dictionary<string, string> GetCompressionMappings()
+    {
+        var factory = DecompressorFactory.Streaming();
+        var keys = factory.GetSupportedKeys();
+        var dict = new Dictionary<string, string>(keys.Length);
+        foreach (var key in keys)
+            dict.Add(key, factory.GetCompression(key));
+        return dict;
+    }
+
+    private static Func<string, bool> GetDatabaseSchemes()
+    {
+        var schemer = new DubUrl.Mapping.SchemeMapperBuilder();
+        schemer.Build();
+        return (scheme) => schemer.CanHandle(scheme);
+    }
+
+    public static ResourceInferenceService None => _none;
+    private static readonly ResourceInferenceService _none = new([]);
+
+    public static ResourceInferenceService Default => _default;
+    private static readonly ResourceInferenceService _default = CreateDefault();
+
+    private static ResourceInferenceService CreateDefault()
+    {
+        var builder = new ResourceInferenceServiceBuilder();
+        builder.AddStrategy(new FormatBasedDialectInference());
+        builder.AddStrategy(new MediaTypeBasedDialectInference());
+        builder.AddStrategy(new ExtensionBasedDialectInference(new ExtractExtensionFromPathsService()));
+        builder.AddStrategy(new MediaTypeBasedFormatInference());
+        builder.AddStrategy(new ExtensionBasedFormatInference(new ExtractExtensionFromPathsService()));
+        builder.AddStrategy(new MediaTypeBasedCompressionInference(_compressionMappings));
+        builder.AddStrategy(new ExtensionBasedCompressionInference(new ExtractExtensionFromPathsService(), _compressionMappings));
+        builder.AddStrategy(new SchemeBasedKindInference((string value) => new string[] { "http", "https" }.Any(x => StringComparer.InvariantCultureIgnoreCase.Compare(x, value) == 0), GetDatabaseSchemes()));
+        return builder.Build();
+    }
+}

--- a/src/Packata.ResourceReaders/Inference/SchemeBasedKindInference.cs
+++ b/src/Packata.ResourceReaders/Inference/SchemeBasedKindInference.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Packata.Core;
+using Packata.Core.Storage;
+
+namespace Packata.ResourceReaders.Inference;
+internal class SchemeBasedKindInference : IKindInference
+{
+    private readonly Func<string, bool> _remoteSchemes;
+    private readonly Func<string, bool> _serviceSchemes;
+
+    public SchemeBasedKindInference(Func<string, bool> remoteSchemes, Func<string, bool> serviceSchemes)
+        => (_remoteSchemes, _serviceSchemes) = (remoteSchemes, serviceSchemes);
+
+    public bool TryInfer(Resource resource, [NotNullWhen(true)] out string? kind)
+    {
+        kind = null;
+        if(!resource.Paths.Any())
+        {
+            if (resource.Data is null)
+            {
+                kind = "virtual";
+                return true;
+            }
+            return false;
+        }
+
+        if (resource.Paths.First() is ContainerPath relativePath)
+        {
+                kind = "local";
+                return true;
+            
+        }
+
+        if (resource.Paths.First() is FullyQualifiedPath absolutePath)
+        {
+            var uri = new Uri(absolutePath.Value);
+            if (_remoteSchemes(uri.Scheme))
+            {
+                kind = "remote";
+                return true;
+            }
+
+            if (_serviceSchemes(uri.Scheme))
+            {
+                kind = "service";
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Packata.ResourceReaders/ResourceReaderFactory.cs
+++ b/src/Packata.ResourceReaders/ResourceReaderFactory.cs
@@ -12,7 +12,7 @@ namespace Packata.ResourceReaders;
 public class ResourceReaderFactory
 {
     private Dictionary<string, IResourceReaderFactory> Factories { get; } = [];
-    private readonly IResourceInferenceService _inferenceService = ResourceInferenceService.Instance;
+    private readonly IResourceInferenceService _inferenceService = ResourceInferenceServiceBuilder.Default;
 
     public ResourceReaderFactory()
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Kind" property for resources, allowing classification as "local", "remote", "service", or "virtual".
  - Added support for automatic inference of the "Kind" property based on resource paths and schemes.
- **Bug Fixes**
  - Improved nullability handling in inference methods for better static analysis and reliability.
- **Refactor**
  - Unified and streamlined the resource inference system for extensibility and maintainability.
- **Tests**
  - Added comprehensive tests for "Kind" inference and refactored existing inference tests for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->