### PR TITLE
chore: bump DubUrl, DubUrl.BulkCopy and DubUrl.Schema from 0.28.2 to 0.28.12

### DIFF
--- a/src/Packata.Provisioners/Packata.Provisioners.csproj
+++ b/src/Packata.Provisioners/Packata.Provisioners.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DubUrl.BulkCopy" Version="0.28.2" />
-    <PackageReference Include="DubUrl.Schema" Version="0.28.2" />
+    <PackageReference Include="DubUrl.BulkCopy" Version="0.28.12" />
+    <PackageReference Include="DubUrl.Schema" Version="0.28.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
+++ b/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DubUrl" Version="0.28.2" />
+    <PackageReference Include="DubUrl" Version="0.28.12" />
     <PackageReference Include="ExcelDataReader" Version="3.7.0" />
     <PackageReference Include="Parquet.Net" Version="5.1.1" />
     <PackageReference Include="PocketCsvReader" Version="2.36.2" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated underlying package dependencies to improve stability and compatibility. No changes to features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->