### PR TITLE
chore: bump PocketCsvReader from 2.36.2 to 2.36.3

### DIFF
--- a/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
+++ b/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="DubUrl" Version="0.28.12" />
     <PackageReference Include="ExcelDataReader" Version="3.7.0" />
     <PackageReference Include="Parquet.Net" Version="5.1.1" />
-    <PackageReference Include="PocketCsvReader" Version="2.36.2" />
+    <PackageReference Include="PocketCsvReader" Version="2.36.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the underlying CSV reader library to a newer version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->