### PR TITLE
chore: bump DubUrl from 0.28.12 to 0.29.2

### DIFF
--- a/src/Packata.Provisioners/Packata.Provisioners.csproj
+++ b/src/Packata.Provisioners/Packata.Provisioners.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DubUrl.BulkCopy" Version="0.28.12" />
-    <PackageReference Include="DubUrl.Schema" Version="0.28.12" />
+    <PackageReference Include="DubUrl.BulkCopy" Version="0.29.2" />
+    <PackageReference Include="DubUrl.Schema" Version="0.29.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
+++ b/src/Packata.ResourceReaders/Packata.ResourceReaders.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DubUrl" Version="0.28.12" />
+    <PackageReference Include="DubUrl" Version="0.29.2" />
     <PackageReference Include="ExcelDataReader" Version="3.7.0" />
     <PackageReference Include="Parquet.Net" Version="5.1.1" />
     <PackageReference Include="PocketCsvReader" Version="2.36.4" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated underlying package dependencies to their latest versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->