### PR TITLE
chore: bump Microsoft.NET.Test.Sdk from 17.14.0 to 17.14.1

### DIFF
--- a/src/Packata.Core.Testing/Packata.Core.Testing.csproj
+++ b/src/Packata.Core.Testing/Packata.Core.Testing.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Chrononuensis" Version="0.23.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />

--- a/src/Packata.Provisioners.Testing/Packata.Provisioners.Testing.csproj
+++ b/src/Packata.Provisioners.Testing/Packata.Provisioners.Testing.csproj
@@ -3,7 +3,7 @@
     <PackageReference Include="Chrononuensis" Version="0.23.9" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />

--- a/src/Packata.ResourceReaders.Testing/Packata.ResourceReaders.Testing.csproj
+++ b/src/Packata.ResourceReaders.Testing/Packata.ResourceReaders.Testing.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Chrononuensis" Version="0.23.9" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />

--- a/src/Packata.Storages.Testing/Packata.Storages.Testing.csproj
+++ b/src/Packata.Storages.Testing/Packata.Storages.Testing.csproj
@@ -3,7 +3,7 @@
     <PackageReference Include="Chrononuensis" Version="0.23.9" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the test framework dependency to the latest version for improved stability and compatibility across multiple testing modules. No functional changes to the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->